### PR TITLE
remove old orbit-db-io dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "homepage": "https://github.com/orbitdb/orbit-db-access-controllers#readme",
   "dependencies": {
-    "orbit-db-io": "^0.2.0",
     "p-map-series": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
will fix an issue with the old orbit-db-io dep pulling an old CID version that causes ipfs.dag.get to hang